### PR TITLE
Add NullSec WiFi Pineapple Suite to Wireless Pentest section

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,10 @@ English | [简体中文](./README_CN.md)
 
 > ![](https://img.shields.io/badge/Score-%E2%98%85%E2%98%85%E2%98%85%E2%98%85-yellow?style=flat-square)  ![](https://img.shields.io/badge/MainLanguage-Python-blue?style=flat-square)  ![GitHub language count](https://img.shields.io/github/languages/count/pinecone-wifi/pinecone?style=flat-square)  ![GitHub last commit](https://img.shields.io/github/last-commit/pinecone-wifi/pinecone?style=flat-square) ![GitHub stars](https://img.shields.io/github/stars/pinecone-wifi/pinecone?style=flat-square)  ![GitHub](https://img.shields.io/github/license/pinecone-wifi/pinecone?style=flat-square)
 
+- https://github.com/bad-antics/hak5-pineapple - **56+ WiFi Pineapple payload suite for wireless auditing, deauth, recon, evil twin, handshake capture and more**
+
+> ![](https://img.shields.io/badge/Score-%E2%98%85%E2%98%85%E2%98%85%E2%98%85%E2%98%85-yellow?style=flat-square)  ![](https://img.shields.io/badge/MainLanguage-Bash-blue?style=flat-square)  ![GitHub language count](https://img.shields.io/github/languages/count/bad-antics/hak5-pineapple?style=flat-square)  ![GitHub last commit](https://img.shields.io/github/last-commit/bad-antics/hak5-pineapple?style=flat-square) ![GitHub stars](https://img.shields.io/github/stars/bad-antics/hak5-pineapple?style=flat-square)  ![GitHub](https://img.shields.io/github/license/bad-antics/hak5-pineapple?style=flat-square)
+
 
 ### Mobile Apps Packages Analysis
 


### PR DESCRIPTION
## Addition

Added [NullSec WiFi Pineapple Suite](https://github.com/bad-antics/hak5-pineapple) to the **Wireless Pentest** section.

### About the tool

- **56+ automated WiFi Pineapple payloads** for wireless security auditing
- Covers deauthentication, evil twin, WPA handshake capture, beacon spam, probe hunting, PMKID capture, karma attacks, and more
- Designed for the Hak5 WiFi Pineapple Mark VII
- All payloads follow the standard Pineapple Pager format with proper payload.sh and payload.conf
- Actively maintained with comprehensive documentation

### Why it fits Scanners-Box

This suite fills a gap in the Wireless Pentest category — most tools listed are software-based WiFi auditing tools, but none specifically target the WiFi Pineapple hardware platform which is widely used in professional penetration testing.

Follows the existing badge format used throughout the list.