### PR TITLE
Fix the broken star history chart across all READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1647,7 +1647,7 @@ We would like to thanks the following security researchers for their valuable fe
     <img src="https://img.shields.io/github/stars/We5ter/Scanners-Box?style=for-the-badge&logo=github&color=%23a78bfa&label=⭐%20Star" alt="GitHub Stars">
   </a>
   <br/><br/>
-  <img src="https://api.star-history.com/svg?repos=We5ter/Scanners-Box&type=Date&theme=dark" alt="Star History Chart">
+  <img src="https://star-history.dera.page/svg?repos=We5ter/Scanners-Box&type=Date&theme=dark" alt="Star History Chart">
 </p>
 
 &copy;<a href="https://github.com/monsterzer0" target="_blank">Monster  Zero Team</a> 2017-2026

--- a/README_CN.md
+++ b/README_CN.md
@@ -1650,7 +1650,7 @@
     <img src="https://img.shields.io/github/stars/We5ter/Scanners-Box?style=for-the-badge&logo=github&color=%23a78bfa&label=⭐%20Star" alt="GitHub Stars">
   </a>
   <br/><br/>
-  <img src="https://api.star-history.com/svg?repos=We5ter/Scanners-Box&type=Date&theme=dark" alt="Star History Chart">
+  <img src="https://star-history.dera.page/svg?repos=We5ter/Scanners-Box&type=Date&theme=dark" alt="Star History Chart">
 </p>
 
 

--- a/README_ES.md
+++ b/README_ES.md
@@ -1620,7 +1620,7 @@ Agradecemos a los siguientes investigadores de seguridad:
     <img src="https://img.shields.io/github/stars/We5ter/Scanners-Box?style=for-the-badge&logo=github&color=%23a78bfa&label=⭐%20Star" alt="GitHub Stars">
   </a>
   <br/><br/>
-  <img src="https://api.star-history.com/svg?repos=We5ter/Scanners-Box&type=Date&theme=dark" alt="Star History Chart">
+  <img src="https://star-history.dera.page/svg?repos=We5ter/Scanners-Box&type=Date&theme=dark" alt="Star History Chart">
 </p>
 
 


### PR DESCRIPTION
The star history chart in the READMEs is currently broken and fails to render. This change swaps the chart image source for a working one in README.md, README_CN.md, and README_ES.md so the stargazer history is visible again. The GitHub stars badge is left untouched.